### PR TITLE
Add compatibleSync method for DataStack.

### DIFF
--- a/Source/Sync/Sync+ObjC.swift
+++ b/Source/Sync/Sync+ObjC.swift
@@ -34,6 +34,20 @@
     }
 }
 
+public extension DataStack {
+
+    public func compatibleSync(_ changes: [[String: Any]], inEntityNamed entityName: String, operations: CompatibleOperationOptions, completion: ((_ error: NSError?) -> Void)?) {
+        Sync.changes(changes, inEntityNamed: entityName, predicate: nil, dataStack: self, operations: operations.operationOptions, completion: completion)
+    }
+    
+    public func compatibleSync(_ changes: [[String: Any]], inEntityNamed entityName: String, predicate: NSPredicate?, operations: CompatibleOperationOptions, completion: ((_ error: NSError?) -> Void)?) {
+        self.performInNewBackgroundContext { backgroundContext in
+            Sync.changes(changes, inEntityNamed: entityName, predicate: predicate, parent: nil, parentRelationship: nil, inContext: backgroundContext, operations: operations.operationOptions, completion: completion)
+        }
+    }
+    
+}
+
 public extension Sync {
     
     /**

--- a/Source/Sync/Sync+ObjC.swift
+++ b/Source/Sync/Sync+ObjC.swift
@@ -36,10 +36,33 @@
 
 public extension DataStack {
 
+    /// Added support for Objective-C.
+    /// Syncs the entity using the received array of dictionaries, maps one-to-many, many-to-many and one-to-one relationships.
+    /// It also syncs relationships where only the id is present, for example if your model is: Company -> Employee,
+    /// and your employee has a company_id, it will try to sync using that ID instead of requiring you to provide the
+    /// entire company object inside the employees dictionary.
+    ///
+    /// - Parameters:
+    ///   - changes: The array of dictionaries used in the sync process.
+    ///   - entityName: The name of the entity to be synced.
+    ///   - operations: The type of operations to be applied to the data, it should be a value of CompatibleOperationOptions.
+    ///   - completion: The completion block, it returns an error if something in the Sync process goes wrong.
     public func compatibleSync(_ changes: [[String: Any]], inEntityNamed entityName: String, operations: CompatibleOperationOptions, completion: ((_ error: NSError?) -> Void)?) {
         Sync.changes(changes, inEntityNamed: entityName, predicate: nil, dataStack: self, operations: operations.operationOptions, completion: completion)
     }
     
+    /// Added support for Objective-C.
+    /// Syncs the entity using the received array of dictionaries, maps one-to-many, many-to-many and one-to-one relationships.
+    /// It also syncs relationships where only the id is present, for example if your model is: Company -> Employee,
+    /// and your employee has a company_id, it will try to sync using that ID instead of requiring you to provide the
+    /// entire company object inside the employees dictionary.
+    ///
+    /// - Parameters:
+    ///   - changes: The array of dictionaries used in the sync process.
+    ///   - entityName: The name of the entity to be synced.
+    ///   - predicate: The predicate used to filter out changes, if you want to exclude some local items to be taken in account in the Sync process, you just need to provide this predicate.
+    ///   - operations: The type of operations to be applied to the data, it should be a value of CompatibleOperationOptions.
+    ///   - completion: The completion block, it returns an error if something in the Sync process goes wrong.
     public func compatibleSync(_ changes: [[String: Any]], inEntityNamed entityName: String, predicate: NSPredicate?, operations: CompatibleOperationOptions, completion: ((_ error: NSError?) -> Void)?) {
         self.performInNewBackgroundContext { backgroundContext in
             Sync.changes(changes, inEntityNamed: entityName, predicate: predicate, parent: nil, parentRelationship: nil, inContext: backgroundContext, operations: operations.operationOptions, completion: completion)


### PR DESCRIPTION
I found sync method of DataStack cannot use operations too, so I made this pull request.