### PR TITLE
Update Sync.swift

### DIFF
--- a/Source/Sync/Sync.swift
+++ b/Source/Sync/Sync.swift
@@ -13,6 +13,7 @@ public protocol SyncDelegate: class {
     func sync(_ sync: Sync, willInsert json: [String: Any], in entityNamed: String, parent: NSManagedObject?) -> [String: Any]
 }
 
+@objcMembers
 @objc public class Sync: Operation {
     public weak var delegate: SyncDelegate?
 


### PR DESCRIPTION
Support objective c with swift4.

At the moment your project is not supporting objective c with swift 4.
For more information take a look of this: http://evgenii.com/blog/disabling-swift3-objc-inference-in-xcode9/

Functions like this are not working:
        [Sync changes: responseObject[@"tags"]
        inEntityNamed:@"TagsCoreData"
            dataStack:self.dataStack
           completion:nil];

Please accept the pull request to enable objective c with swift4.  thanks