### PR TITLE
Fix 476

### DIFF
--- a/Project.xcodeproj/project.pbxproj
+++ b/Project.xcodeproj/project.pbxproj
@@ -692,6 +692,12 @@
 		44E38B322005EEB2003E896B /* 422-one-to-one-insert-option-initial.json in Resources */ = {isa = PBXBuildFile; fileRef = 44E38B222005EEB2003E896B /* 422-one-to-one-insert-option-initial.json */; };
 		44E38B332005EEB2003E896B /* 422-one-to-one-insert-option-initial.json in Resources */ = {isa = PBXBuildFile; fileRef = 44E38B222005EEB2003E896B /* 422-one-to-one-insert-option-initial.json */; };
 		44E38B342005EEB2003E896B /* 422-one-to-one-insert-option-initial.json in Resources */ = {isa = PBXBuildFile; fileRef = 44E38B222005EEB2003E896B /* 422-one-to-one-insert-option-initial.json */; };
+		44F3DC07202ED3B600A42022 /* 476.json in Resources */ = {isa = PBXBuildFile; fileRef = 44F3DC06202ED3B600A42022 /* 476.json */; };
+		44F3DC08202ED3B600A42022 /* 476.json in Resources */ = {isa = PBXBuildFile; fileRef = 44F3DC06202ED3B600A42022 /* 476.json */; };
+		44F3DC09202ED3B600A42022 /* 476.json in Resources */ = {isa = PBXBuildFile; fileRef = 44F3DC06202ED3B600A42022 /* 476.json */; };
+		44F3DC0C202ED40500A42022 /* 476.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 44F3DC0A202ED40500A42022 /* 476.xcdatamodeld */; };
+		44F3DC0D202ED40500A42022 /* 476.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 44F3DC0A202ED40500A42022 /* 476.xcdatamodeld */; };
+		44F3DC0E202ED40500A42022 /* 476.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 44F3DC0A202ED40500A42022 /* 476.xcdatamodeld */; };
 		CC86E0A120216FCC00AA0947 /* 447.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = CC86E09F20216FCC00AA0947 /* 447.xcdatamodeld */; };
 		CC86E0A220216FCC00AA0947 /* 447.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = CC86E09F20216FCC00AA0947 /* 447.xcdatamodeld */; };
 		CC86E0A320216FCC00AA0947 /* 447.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = CC86E09F20216FCC00AA0947 /* 447.xcdatamodeld */; };
@@ -1019,6 +1025,8 @@
 		44E38B202005EEB2003E896B /* 422-one-to-one-delete-option-initial.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "422-one-to-one-delete-option-initial.json"; sourceTree = "<group>"; };
 		44E38B212005EEB2003E896B /* 422-one-to-one-delete-option-update.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "422-one-to-one-delete-option-update.json"; sourceTree = "<group>"; };
 		44E38B222005EEB2003E896B /* 422-one-to-one-insert-option-initial.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "422-one-to-one-insert-option-initial.json"; sourceTree = "<group>"; };
+		44F3DC06202ED3B600A42022 /* 476.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = 476.json; sourceTree = "<group>"; };
+		44F3DC0B202ED40500A42022 /* 476.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = 476.xcdatamodel; sourceTree = "<group>"; };
 		CC86E0A020216FCC00AA0947 /* 413.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = 413.xcdatamodel; sourceTree = "<group>"; };
 		CC86E0A420216FF300AA0947 /* primary-key-organizations.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "primary-key-organizations.json"; sourceTree = "<group>"; };
 		CC86E0A520216FF300AA0947 /* 447.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = 447.json; sourceTree = "<group>"; };
@@ -1285,6 +1293,7 @@
 				CC86E0A520216FF300AA0947 /* 447.json */,
 				1AFF18C91FE1F08800C4BC3D /* 457-products.json */,
 				1AFF18CA1FE1F08800C4BC3D /* 457-subcategories.json */,
+				44F3DC06202ED3B600A42022 /* 476.json */,
 				14867D351E7AF4D2001D228A /* bug-113-comments-no-id.json */,
 				14867D361E7AF4D2001D228A /* bug-113-custom_relationship_key_to_one.json */,
 				14867D371E7AF4D2001D228A /* bug-113-stories-comments-no-ids.json */,
@@ -1365,6 +1374,7 @@
 				44E38AE52005927E003E896B /* 422OneToOne.xcdatamodeld */,
 				CC86E09F20216FCC00AA0947 /* 447.xcdatamodeld */,
 				4494AEA21FE5E1CD0064999E /* 457.xcdatamodeld */,
+				44F3DC0A202ED40500A42022 /* 476.xcdatamodeld */,
 				14867D881E7AF4D2001D228A /* Camelcase.xcdatamodeld */,
 				14867D8A1E7AF4D2001D228A /* Contacts.xcdatamodeld */,
 				14867D8C1E7AF4D2001D228A /* CustomRelationshipKey.xcdatamodeld */,
@@ -1970,6 +1980,7 @@
 				14867E8A1E7AF4D2001D228A /* markets_items.json in Resources */,
 				14867E631E7AF4D2001D228A /* bug-179-routes.json in Resources */,
 				14867DDC1E7AF4D2001D228A /* simple.json in Resources */,
+				44F3DC07202ED3B600A42022 /* 476.json in Resources */,
 				14867E2D1E7AF4D2001D228A /* 225-a-empty.json in Resources */,
 				14867E571E7AF4D2001D228A /* bug-113-stories-comments-no-ids.json in Resources */,
 				CC86E0AE20216FF400AA0947 /* primary-key-users.json in Resources */,
@@ -2078,6 +2089,7 @@
 				14867E8B1E7AF4D2001D228A /* markets_items.json in Resources */,
 				14867E641E7AF4D2001D228A /* bug-179-routes.json in Resources */,
 				14867DDD1E7AF4D2001D228A /* simple.json in Resources */,
+				44F3DC08202ED3B600A42022 /* 476.json in Resources */,
 				14867E2E1E7AF4D2001D228A /* 225-a-empty.json in Resources */,
 				14867E581E7AF4D2001D228A /* bug-113-stories-comments-no-ids.json in Resources */,
 				CC86E0AF20216FF400AA0947 /* primary-key-users.json in Resources */,
@@ -2186,6 +2198,7 @@
 				14867E8C1E7AF4D2001D228A /* markets_items.json in Resources */,
 				14867E651E7AF4D2001D228A /* bug-179-routes.json in Resources */,
 				14867DDE1E7AF4D2001D228A /* simple.json in Resources */,
+				44F3DC09202ED3B600A42022 /* 476.json in Resources */,
 				14867E2F1E7AF4D2001D228A /* 225-a-empty.json in Resources */,
 				14867E591E7AF4D2001D228A /* bug-113-stories-comments-no-ids.json in Resources */,
 				CC86E0B020216FF400AA0947 /* primary-key-users.json in Resources */,
@@ -2370,6 +2383,7 @@
 				14867EF91E7AF4D2001D228A /* 280.xcdatamodeld in Sources */,
 				14867F111E7AF4D2001D228A /* id.xcdatamodeld in Sources */,
 				445851EB1E87BAF60025434E /* DateStringTransformer.m in Sources */,
+				44F3DC0C202ED40500A42022 /* 476.xcdatamodeld in Sources */,
 				44E38AE020059146003E896B /* 422OneToMany.xcdatamodeld in Sources */,
 				445851EE1E87BAF60025434E /* SyncTestValueTransformer.m in Sources */,
 				14867F411E7AF4D2001D228A /* NSManagedObjectContext+SyncTests.swift in Sources */,
@@ -2467,6 +2481,7 @@
 				14867EFA1E7AF4D2001D228A /* 280.xcdatamodeld in Sources */,
 				14867F121E7AF4D2001D228A /* id.xcdatamodeld in Sources */,
 				445851EC1E87BAF60025434E /* DateStringTransformer.m in Sources */,
+				44F3DC0D202ED40500A42022 /* 476.xcdatamodeld in Sources */,
 				44E38AE120059146003E896B /* 422OneToMany.xcdatamodeld in Sources */,
 				445851EF1E87BAF60025434E /* SyncTestValueTransformer.m in Sources */,
 				14867F421E7AF4D2001D228A /* NSManagedObjectContext+SyncTests.swift in Sources */,
@@ -2564,6 +2579,7 @@
 				14867EFB1E7AF4D2001D228A /* 280.xcdatamodeld in Sources */,
 				14867F131E7AF4D2001D228A /* id.xcdatamodeld in Sources */,
 				445851ED1E87BAF60025434E /* DateStringTransformer.m in Sources */,
+				44F3DC0E202ED40500A42022 /* 476.xcdatamodeld in Sources */,
 				44E38AE220059146003E896B /* 422OneToMany.xcdatamodeld in Sources */,
 				445851F01E87BAF60025434E /* SyncTestValueTransformer.m in Sources */,
 				14867F431E7AF4D2001D228A /* NSManagedObjectContext+SyncTests.swift in Sources */,
@@ -3720,6 +3736,16 @@
 			);
 			currentVersion = 44E38AE62005927E003E896B /* 422OneToOne.xcdatamodel */;
 			path = 422OneToOne.xcdatamodeld;
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+		44F3DC0A202ED40500A42022 /* 476.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				44F3DC0B202ED40500A42022 /* 476.xcdatamodel */,
+			);
+			currentVersion = 44F3DC0B202ED40500A42022 /* 476.xcdatamodel */;
+			path = 476.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;
 		};

--- a/Project.xcodeproj/xcshareddata/xcschemes/Sync-macOS.xcscheme
+++ b/Project.xcodeproj/xcshareddata/xcschemes/Sync-macOS.xcscheme
@@ -29,7 +29,26 @@
       language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "14975BF31DBC36960024901A"
+               BuildableName = "macOSTests.xctest"
+               BlueprintName = "macOSTests"
+               ReferencedContainer = "container:Project.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "14241E971DBC39730042ED81"
+            BuildableName = "Sync.framework"
+            BlueprintName = "Sync-macOS"
+            ReferencedContainer = "container:Project.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>

--- a/Source/Sync/NSManagedObject+Sync.swift
+++ b/Source/Sync/NSManagedObject+Sync.swift
@@ -321,7 +321,17 @@ extension NSManagedObject {
                 if ((childIDs as Any) as AnyObject).count > 0 {
                     guard let entity = NSEntityDescription.entity(forEntityName: childEntityName, in: context) else { fatalError() }
                     guard let childIDsObject = childIDs as? NSObject else { fatalError() }
-                    childPredicate = NSPredicate(format: "ANY %K IN %@ OR %K = %@", entity.sync_localPrimaryKey(), childIDsObject, inverseEntityName, self)
+                    let primaryKeyAttribute = entity.sync_primaryKeyAttribute()
+
+                    var ids = [Any]()
+                    let childrenIDs = (((childIDsObject as Any) as AnyObject) as? NSArray) ?? NSArray()
+                    for id in childrenIDs {
+                        if let newID = value(forAttributeDescription: primaryKeyAttribute, usingRemoteValue: id) {
+                            ids.append(newID)
+                        }
+                    }
+
+                    childPredicate = NSPredicate(format: "ANY %K IN %@ OR %K = %@", entity.sync_localPrimaryKey(), ids, inverseEntityName, self)
                 }
             }
 

--- a/Source/Sync/NSManagedObject+Sync.swift
+++ b/Source/Sync/NSManagedObject+Sync.swift
@@ -316,13 +316,12 @@ extension NSManagedObject {
                 }
             } else {
                 guard let inverseEntityName = relationship.inverseRelationship?.name else { fatalError() }
+                childPredicate = NSPredicate(format: "%K = %@", inverseEntityName, self)
 
                 if ((childIDs as Any) as AnyObject).count > 0 {
                     guard let entity = NSEntityDescription.entity(forEntityName: childEntityName, in: context) else { fatalError() }
                     guard let childIDsObject = childIDs as? NSObject else { fatalError() }
                     childPredicate = NSPredicate(format: "ANY %K IN %@ OR %K = %@", entity.sync_localPrimaryKey(), childIDsObject, inverseEntityName, self)
-                } else {
-                    childPredicate = NSPredicate(format: "%K = %@", inverseEntityName, self)
                 }
             }
 

--- a/Source/Sync/NSManagedObject+Sync.swift
+++ b/Source/Sync/NSManagedObject+Sync.swift
@@ -319,7 +319,6 @@ extension NSManagedObject {
                 } else {
                     guard let inverseEntityName = relationship.inverseRelationship?.name else { fatalError() }
                     let primaryKeyAttribute = entity.sync_primaryKeyAttribute()
-
                     let ids = childrenIDs.flatMap { value(forAttributeDescription: primaryKeyAttribute, usingRemoteValue: $0) }
                     childPredicate = NSPredicate(format: "ANY %K IN %@ OR %K = %@", entity.sync_localPrimaryKey(), ids, inverseEntityName, self)
                 }

--- a/Source/Sync/NSManagedObject+Sync.swift
+++ b/Source/Sync/NSManagedObject+Sync.swift
@@ -319,6 +319,10 @@ extension NSManagedObject {
                 } else {
                     guard let inverseEntityName = relationship.inverseRelationship?.name else { fatalError() }
                     let primaryKeyAttribute = entity.sync_primaryKeyAttribute()
+
+                    // Required in order to convert the JSON IDs into the same type as the ones Core Data expects. If the local primary key
+                    // is of type Date, then we need to convert the array of strings in the JSON to be an array of dates.
+                    // More info: https://github.com/3lvis/Sync/pull/477
                     let ids = childrenIDs.flatMap { value(forAttributeDescription: primaryKeyAttribute, usingRemoteValue: $0) }
                     childPredicate = NSPredicate(format: "ANY %K IN %@ OR %K = %@", entity.sync_localPrimaryKey(), ids, inverseEntityName, self)
                 }

--- a/Source/Sync/NSManagedObject+Sync.swift
+++ b/Source/Sync/NSManagedObject+Sync.swift
@@ -316,12 +316,13 @@ extension NSManagedObject {
                 }
             } else {
                 guard let inverseEntityName = relationship.inverseRelationship?.name else { fatalError() }
-                childPredicate = NSPredicate(format: "%K = %@", inverseEntityName, self)
 
                 if ((childIDs as Any) as AnyObject).count > 0 {
                     guard let entity = NSEntityDescription.entity(forEntityName: childEntityName, in: context) else { fatalError() }
                     guard let childIDsObject = childIDs as? NSObject else { fatalError() }
                     childPredicate = NSPredicate(format: "ANY %K IN %@ OR %K = %@", entity.sync_localPrimaryKey(), childIDsObject, inverseEntityName, self)
+                } else {
+                    childPredicate = NSPredicate(format: "%K = %@", inverseEntityName, self)
                 }
             }
 

--- a/Tests/Sync/JSONs/476.json
+++ b/Tests/Sync/JSONs/476.json
@@ -1,0 +1,35 @@
+[
+  {
+    "userWeight": [
+      {
+        "isDeleted": false,
+        "measuredAt": "2018-01-25T21:00:00.000Z",
+        "weightValue": 82.299999999999997
+      },
+      {
+        "isDeleted": true,
+        "measuredAt": "2018-02-01T21:00:00.000Z",
+        "weightValue": 63.299999999999997
+      },
+      {
+        "isDeleted": false,
+        "measuredAt": "2018-02-07T21:00:00.000Z",
+        "weightValue": 64.299999999999997
+      },
+      {
+        "isDeleted": false,
+        "measuredAt": "2018-02-05T21:00:00.000Z",
+        "weightValue": 65.299999999999997
+      },
+      {
+        "isDeleted": false,
+        "measuredAt": "2018-02-09T21:00:00.000Z",
+        "weightValue": 69.5
+      }
+    ],
+    "_id": "YMBG9ZoSw57Zd77XT",
+    "createdBy": "5PqJrXFLwQNLaYyeD",
+    "userLastWeight": 69.5,
+    "createdAt": "2018-02-09T12:22:39.573Z"
+  }
+]

--- a/Tests/Sync/JSONs/476.json
+++ b/Tests/Sync/JSONs/476.json
@@ -2,34 +2,9 @@
   {
     "userWeight": [
       {
-        "isDeleted": false,
-        "measuredAt": "2018-01-25T21:00:00.000Z",
-        "weightValue": 82.299999999999997
-      },
-      {
-        "isDeleted": true,
-        "measuredAt": "2018-02-01T21:00:00.000Z",
-        "weightValue": 63.299999999999997
-      },
-      {
-        "isDeleted": false,
-        "measuredAt": "2018-02-07T21:00:00.000Z",
-        "weightValue": 64.299999999999997
-      },
-      {
-        "isDeleted": false,
-        "measuredAt": "2018-02-05T21:00:00.000Z",
-        "weightValue": 65.299999999999997
-      },
-      {
-        "isDeleted": false,
-        "measuredAt": "2018-02-09T21:00:00.000Z",
-        "weightValue": 69.5
+        "measuredAt": "2018-02-09T21:00:00.000Z"
       }
     ],
-    "_id": "YMBG9ZoSw57Zd77XT",
-    "createdBy": "5PqJrXFLwQNLaYyeD",
-    "userLastWeight": 69.5,
-    "createdAt": "2018-02-09T12:22:39.573Z"
+    "_id": "YMBG9ZoSw57Zd77XT"
   }
 ]

--- a/Tests/Sync/Models/476.xcdatamodeld/476.xcdatamodel/contents
+++ b/Tests/Sync/Models/476.xcdatamodeld/476.xcdatamodel/contents
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="13772" systemVersion="17D47" minimumToolsVersion="Xcode 7.0" sourceLanguage="Objective-C" userDefinedModelVersionIdentifier="">
+    <entity name="FitnessProfile" syncable="YES">
+        <attribute name="id" optional="YES" attributeType="String" syncable="YES">
+            <userInfo>
+                <entry key="sync.isPrimaryKey" value="true"/>
+                <entry key="sync.remoteKey" value="_id"/>
+            </userInfo>
+        </attribute>
+        <relationship name="userWeight" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="UserWeight" inverseName="fitnessProfile" inverseEntity="UserWeight" syncable="YES"/>
+    </entity>
+    <entity name="UserWeight" syncable="YES">
+        <attribute name="measuredAt" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES">
+            <userInfo>
+                <entry key="sync.isPrimaryKey" value="true"/>
+                <entry key="sync.remoteKey" value="measuredAt"/>
+            </userInfo>
+        </attribute>
+        <relationship name="fitnessProfile" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="FitnessProfile" inverseName="userWeight" inverseEntity="FitnessProfile" syncable="YES"/>
+    </entity>
+    <elements>
+        <element name="UserWeight" positionX="-234" positionY="-18" width="128" height="73"/>
+        <element name="FitnessProfile" positionX="-54" positionY="-9" width="128" height="73"/>
+    </elements>
+</model>

--- a/Tests/Sync/SyncTests.swift
+++ b/Tests/Sync/SyncTests.swift
@@ -1718,7 +1718,7 @@ class SyncTests: XCTestCase {
         dataStack.sync(data, inEntityNamed: "FitnessProfile", completion: nil)
 
         XCTAssertEqual(Helper.countForEntity("FitnessProfile", inContext: dataStack.mainContext), 1)
-        XCTAssertEqual(Helper.countForEntity("UserWeight", inContext: dataStack.mainContext), 5)
+        XCTAssertEqual(Helper.countForEntity("UserWeight", inContext: dataStack.mainContext), 1)
 
         dataStack.drop()
     }

--- a/Tests/Sync/SyncTests.swift
+++ b/Tests/Sync/SyncTests.swift
@@ -1709,4 +1709,17 @@ class SyncTests: XCTestCase {
 
         dataStack.drop()
     }
+
+    // https://github.com/3lvis/Sync/issues/476
+    func test476() {
+        let dataStack = Helper.dataStackWithModelName("476")
+
+        let data = Helper.objectsFromJSON("476.json") as! [[String: Any]]
+        dataStack.sync(data, inEntityNamed: "FitnessProfile", completion: nil)
+
+        XCTAssertEqual(Helper.countForEntity("FitnessProfile", inContext: dataStack.mainContext), 1)
+        XCTAssertEqual(Helper.countForEntity("UserWeight", inContext: dataStack.mainContext), 5)
+
+        dataStack.drop()
+    }
 }


### PR DESCRIPTION
The bug is caused by the following line:

https://github.com/3lvis/Sync/blob/87cfe00cc93b758431a205991a7044915d2d3169/Source/Sync/NSManagedObject%2BSync.swift#L324

When creating the predicate Core Data expects that the array of elements in the `IN` closure to have the same type have as the ones inserted in Core Data. In this specific case, we have an array of Strings coming from the JSON and locally an array of Dates, this causes Core Data to crash when trying to execute the fetch request using the provided predicate since it expects an array of Dates from the JSON as well.

