### PR TITLE
NSDateParser containing upto micro second is mapped upto micro seconds precision in core data

### DIFF
--- a/Source/DateParser/NSDate+PropertyMapper.m
+++ b/Source/DateParser/NSDate+PropertyMapper.m
@@ -117,6 +117,15 @@
             hasMicroseconds = YES;
         }
 
+        // Copy all the date excluding the microseconds and the z also set `hasMicroseconds` to YES.
+        // Current date: 2015-08-23T09:29:30.007450Z
+        // Will become:  2015-08-23T09:29:30
+        // Unit test M
+        else if (originalLength == 27 && originalString[originalLength - 1] == 'Z') {
+            strncpy(currentString, originalString, 19);
+            hasMicroseconds = YES;
+        }
+
         // Copy all the date excluding the microseconds and the timezone.
         // Current date: 2015-09-10T13:47:21.116+0000
         // Will become:  2015-09-10T13:47:21

--- a/Tests/DateParser/DateTests.swift
+++ b/Tests/DateParser/DateTests.swift
@@ -94,6 +94,16 @@ class DateTests: XCTestCase {
         XCTAssertNotNil(resultDate)
         XCTAssertEqual(date, resultDate)
     }
+    
+    func testDateM() {
+        let date = Date.dateWithHourAndMicrosecondString(dateString: "2015-08-23T09:29:30.007450Z")
+        let resultDate = NSDate(fromDateString: "2015-08-23T09:29:30.007450Z")! as Date
+        XCTAssertNotNil(resultDate)
+        
+        // Avoinding decimal in timerefernce while comparing dates since dateformatter rounds the date value after milliseconds
+        XCTAssertEqual(Int64(date.timeIntervalSince1970), Int64(resultDate.timeIntervalSince1970))
+    }
+
 }
 
 class TimestampDateTests: XCTestCase {
@@ -159,6 +169,15 @@ extension Date {
         formatter.timeZone = TimeZone(identifier: "UTC")
         let date = formatter.date(from: dateString)!
 
+        return date
+    }
+    
+    static func dateWithHourAndMicrosecondString(dateString: String) -> Date {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'"
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        let date = formatter.date(from: dateString)!
+        
         return date
     }
 


### PR DESCRIPTION
Fixed issue in NSDateParser where the date format containing upto micro second is mapped  upto micro seconds  precision in core data