### PR TITLE
issue of duplicated object with the same id

### DIFF
--- a/Tests/Sync/JSONs/camelcase.json
+++ b/Tests/Sync/JSONs/camelcase.json
@@ -1,9 +1,16 @@
 [
-  {
-    "id": "1",
-    "numberOfChildren": 1,
-    "fullName": "Elvis Nuñez",
-    "first_name": "Elvis",
-    "last_name": "Nuñez"
-  }
+ {
+ "id": "1",
+ "numberOfChildren": 1,
+ "fullName": "Elvis Nuñez",
+ "first_name": "Elvis",
+ "last_name": "Nuñez"
+ },
+ {
+ "id": "1",
+ "numberOfChildren": 1,
+ "fullName": "Elvis Nuñez",
+ "first_name": "Elvis",
+ "last_name": "Nuñez"
+ }
 ]

--- a/Tests/Sync/SyncTests.swift
+++ b/Tests/Sync/SyncTests.swift
@@ -11,8 +11,15 @@ class SyncTests: XCTestCase {
         dataStack.sync(objects, inEntityNamed: "NormalUser") { _ in
             synchronous = true
         }
-        XCTAssertTrue(synchronous)
-        dataStack.drop()
+
+		let c = Helper.countForEntity("NormalUser", predicate: nil, inContext: dataStack.mainContext)
+		
+		
+		XCTAssertTrue(synchronous)
+		XCTAssertTrue(c == 1)
+
+		
+		dataStack.drop()
     }
 
     // MARK: - Camelcase


### PR DESCRIPTION
I modified the test `testSynchronous` by duplicating the object in `"camelcase.json"` , 
and testing that only one object should exist with an id (id = 1) .
But the test fails because when fetching for object in context I get duplication of the same object (same id) .

I was expecting that sync will keep only on id = 1 (for bought methods `.sync(...` and `.insertOrUpdate(...` )
Am I wrong ?