### PR TITLE
Support for date format with milliseconds but no Z terminator

### DIFF
--- a/Source/DateParser/NSDate+PropertyMapper.m
+++ b/Source/DateParser/NSDate+PropertyMapper.m
@@ -107,6 +107,15 @@
             hasCentiseconds = YES;
         }
 
+        // Copy all the date excluding the miliseconds.
+        // Current date: 2017-12-22T18:10:14.070
+        // Will become:  2017-12-22T18:10:14
+        // Unit test O
+        else if (originalLength == 23 && originalString[originalLength - 1] != 'Z') {
+            strncpy(currentString, originalString, 19);
+            hasMiliseconds = YES;
+        }
+
         // Copy all the date excluding the miliseconds and the Z.
         // Current date: 2017-11-02T17:27:52.2Z
         // Will become:  2014-03-30T09:13:00

--- a/Tests/DateParser/DateTests.swift
+++ b/Tests/DateParser/DateTests.swift
@@ -108,6 +108,14 @@ class DateTests: XCTestCase {
         XCTAssertNotNil(resultDate)
         XCTAssertEqual(date, resultDate)
     }
+    
+    func testDateO() {
+        let date = Date.dateWithHourAndTimeZoneString(dateString: "2017-12-22T18:10:14.070")
+        let resultDate = NSDate(fromDateString: "2017-12-22T18:10:14.070")! as Date
+        XCTAssertNotNil(resultDate)
+        XCTAssertEqual(date, resultDate)
+    }
+
 }
 
 class TimestampDateTests: XCTestCase {


### PR DESCRIPTION
Added support for date format with milliseconds but no Z terminator: 2017-12-22T18:10:14.070