### PR TITLE
Checking that the context that is being rest for a disposable context is indeed a disposable context

### DIFF
--- a/Source/DataStack/DataStack.swift
+++ b/Source/DataStack/DataStack.swift
@@ -29,6 +29,8 @@ import CoreData
 
     private let backgroundContextName = "DataStack.backgroundContextName"
 
+    private let disposableContextName = "DataStack.disposableContextName"
+
     /**
      The context for the main queue. Please do not use this to mutate data, use `performInNewBackgroundContext`
      instead.
@@ -207,6 +209,7 @@ import CoreData
      */
     @objc public func newDisposableMainContext() -> NSManagedObjectContext {
         let context = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
+        context.name = disposableContextName
         context.persistentStoreCoordinator = self.disposablePersistentStoreCoordinator
         context.undoManager = nil
 
@@ -369,9 +372,12 @@ import CoreData
 
     // Can't be private, has to be internal in order to be used as a selector.
     @objc func newDisposableMainContextWillSave(_ notification: Notification) {
-        if let context = notification.object as? NSManagedObjectContext {
-            context.reset()
+        let context = notification.object as? NSManagedObjectContext
+        guard context?.name == disposableContextName else {
+            return
         }
+
+        context?.reset()
     }
 
     // Can't be private, has to be internal in order to be used as a selector.
@@ -380,7 +386,7 @@ import CoreData
         guard context?.name == backgroundContextName else {
             return
         }
-        
+
         if Thread.isMainThread && TestCheck.isTesting == false {
             throw NSError(info: "Background context saved in the main thread. Use context's `performBlock`", previousError: nil)
         } else {
@@ -430,7 +436,7 @@ extension NSPersistentStoreCoordinator {
                 }
             }
 
-            let options = [NSMigratePersistentStoresAutomaticallyOption: true, NSInferMappingModelAutomaticallyOption: true, NSSQLitePragmasOption: ["journal_mode": "DELETE"]] as [AnyHashable : Any]
+            let options = [NSMigratePersistentStoresAutomaticallyOption: true, NSInferMappingModelAutomaticallyOption: true, NSSQLitePragmasOption: ["journal_mode": "DELETE"]] as [AnyHashable: Any]
             do {
                 try self.addPersistentStore(ofType: NSSQLiteStoreType, configurationName: nil, at: storeURL, options: options)
             } catch {
@@ -495,13 +501,13 @@ extension FileManager {
     /// The directory URL for the sqlite file.
     public static var sqliteDirectoryURL: URL {
         #if os(tvOS)
-        return FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).last!
-        #else
-        if TestCheck.isTesting {
             return FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).last!
-        } else {
-            return FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).last!
-        }
+        #else
+            if TestCheck.isTesting {
+                return FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).last!
+            } else {
+                return FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).last!
+            }
         #endif
     }
 }

--- a/Sync.podspec
+++ b/Sync.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 s.name             = "Sync"
-s.version          = "6.0.0"
+s.version          = "6.0.1"
 s.summary          = "Modern Swift JSON synchronization to Core Data"
 s.description      = <<-DESC
 **Sync** eases your everyday job of parsing a `JSON` response and getting it into Core Data. It uses a convention-over-configuration paradigm to facilitate your workflow.


### PR DESCRIPTION
Hey @3lvis I am seeing an odd issue when using a disposable context combined with Sync syncing a background context. 

What's happening is I have a disposable context that never has save called on it. It creates a temporary object that is just used to create a request. When that request returns it kicks off Sync which creates a background context. 

I have spend a ton of time trying to track it down but for some reason when the background context is saved it causes the newDisposableMainContextWillSave to be triggered even though the observer was never set on the background context. This causes the background context which data I actually want to be stored to be reset and lost.

I also tried to create a unit test to reproduce this with no success. The even stranger part is it doesn't happen every time.

My fix is simple it just checks if the context calling newDisposableMainContextWillSave is really a disposable context. If not don't reset it.